### PR TITLE
fix: add autoload cookie

### DIFF
--- a/htmlz-mode.el
+++ b/htmlz-mode.el
@@ -1,10 +1,10 @@
-;;; htmlz --- Simple real-time Emacs html preview
+;;; htmlz-mode --- Simple real-time Emacs html preview
 
 ;; Copyright (C) 2020 Zeke Medley
 
 ;; Author: Zeke Medley <zekemedley@gmail.com>
 ;; Keywords: html
-;; Version: 0.1
+;; Version: 0.2
 ;; URL: https://github.com/ZekeMedley/htmlz
 
 ;;; Commentary:
@@ -106,6 +106,7 @@ document.body.innerHTML = event.data;
   (delete-file (htmlz-get-filename))
   (remove-hook 'post-command-hook 'htmlz-send-buffer-contents 'local))
 
+;;;###autoload
 (define-minor-mode htmlz-mode
   "The htmlz minor mode"
   :lighter " htmlz"
@@ -117,4 +118,4 @@ document.body.innerHTML = event.data;
     (htmlz-start)))
 
 (provide 'htmlz-mode)
-;;; htmlz.el ends here
+;;; htmlz-mode.el ends here


### PR DESCRIPTION
It fixes:
https://github.com/0xekez/htmlz-mode/issues/1
https://github.com/0xekez/htmlz-mode/issues/2

- rename htmlz.el -> htmlz-mode.el

It fixes error on `M-x htmlz-mode`:

   apply: Cannot open load file: No such file or directory, htmlz-mode

with the following config in `.emacs` (Emacs 29+):

```emacs-lisp
(use-package htmlz-mode
  :vc (:url "https://github.com/0xekez/htmlz-mode")
  ;; M-x htmlz-mode in html buffer to enable the minor-mode
  :commands htmlz-mode)
```

It works with:
```emacs-lisp
;; ** htmlz-mode -- simple live html preview in browser
(use-package htmlz-mode
  :vc (:url "https://github.com/zed/htmlz-mode"
       :rev "fix/loading-htmlz-mode")
  ;; M-x htmlz-mode in html buffer, to enable the minor-mode
  :commands htmlz-mode)
```